### PR TITLE
Add persistence: SQLite + SQLModel for activities

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,15 @@
+from sqlmodel import SQLModel, create_engine, Session
+import os
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///data.db")
+# If using sqlite, allow cross-thread usage by setting check_same_thread=False
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+
+
+def init_db():
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    return Session(engine)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,18 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+
+class Activity(SQLModel, table=True):
+    name: str = Field(primary_key=True)
+    description: Optional[str] = None
+    schedule: Optional[str] = None
+    max_participants: Optional[int] = None
+    participants: str = Field(default="[]")
+
+    def to_dict(self):
+        import json
+        return {
+            "description": self.description or "",
+            "schedule": self.schedule or "",
+            "max_participants": self.max_participants or 0,
+            "participants": json.loads(self.participants or "[]")
+        }


### PR DESCRIPTION
This PR adds persistent storage for activities using `SQLModel` + SQLite. It includes:

- `src/models.py` - `Activity` model
- `src/db.py` - DB engine and initializer
- `src/app.py` - updated to read/write activities from the DB and bootstrap initial data

Next steps (separate PRs):
- Add auth and protected endpoints
- Add tests and CI

Run locally:

```bash
pip install -r src/requirements.txt
uvicorn src.app:app --reload
```
